### PR TITLE
Update website from CV: office, publications, and teaching fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
           Assistant Professor<br>
           <a href="https://artsandsciences.syracuse.edu/mathematics/" target="_blank">Department of Mathematics</a><br>
           <a href="https://www.syracuse.edu" target="_blank">Syracuse University</a><br>
+          Office: Carnegie 206D<br>
           <br>
           Email: <a href="mailto:sdu113@syr.edu" target="_blank">sdu113@syr.edu</a>
         </p>
@@ -63,7 +64,7 @@
       <li> Scientific machine learning and data-driven methods </li>
       <li> Computational inverse and ill-posed problem </li>
       <li> Numerical methods for radiative transfer </li>
-      <li> Elastic/viscoelastic and electromagnetic waves </li>
+      <li> Electromagnetic and elastic/viscoelastic waves </li>
     </ul>
 
     <a href="research.html">Click</a> for more information

--- a/publications.html
+++ b/publications.html
@@ -18,17 +18,24 @@
   <div class="main">
 
     <header>
-      <h1> Research </h1>
+      <h1> Publications </h1>
     </header>
 
     <h2> Publications </h2>
     <h4> Submitted </h4>
-    <ol type="1" reversed start=16>
-      <li> J. L. Torchinsky, S. Du, S. N. Stechmann. Angular-spatical hp-adaptivity for radiative transfer with discontinuous Galerkin spectral element methods. </li>
+    <ol type="1" reversed start=19>
+      <li> B. Cockburn, S. Du, M. A. S&aacute;nchez. A spectral analysis of hp-hybridized mixed and HDG methods for parametric second-order elliptic problems. </li>
+      <li> S. Du, T. Le, S. N. Stechmann. Element learning with hp-adaptivity: machine learning-based acceleration of hp-adaptive spectral element methods, and application to atmospheric radiative transfer. </li>
     </ol>
 
     <h4> Peer-reviewed</h4>
-    <ol type="1" reversed start=15>
+    <ol type="1" reversed start=17>
+      <li> J. L. Torchinsky, S. Du, and S. N. Stechmann. Angular-spatial hp-adaptivity for radiative transfer with discontinuous Galerkin spectral element methods. <br>
+        J. Quant. Spectrosc. Radiat. Transf. 348 (2026).
+        <a href="https://doi.org/10.1016/j.jqsrt.2025.109687" target="_blank"> DOI: 10.1016/j.jqsrt.2025.109687 </a> </li>
+      <li> D. H. Marsico, S. Du, and S. N. Stechmann. Can second-order numerical accuracy be achieved for moist atmospheric dynamics with non-smoothness at cloud edge? <br>
+        J. Adv. Model. Earth Syst. 17 (2025).
+        <a href="https://doi.org/10.1029/2025MS005293" target="_blank"> DOI: 10.1029/2025MS005293 </a> </li>
       <li> S. Du, and S. N. Stechmann. Element learning: a systematic approach of accelerating finite element-type methods via machine learning, with applications to radiative transfer. <br>
         J. Comput. Math. (2024).
         <a href="https://doi.org/10.4208/jcm.2407-m2024-0047" target="_blank"> DOI: 10.4208/jcm.2407-m2024-0047 </a> </li>
@@ -36,15 +43,15 @@
         Inverse Probl. 39 (2023), no. 11.
         <a href="https://doi.org/10.1088/1361-6420/acf785" target="_blank"> DOI: 10.1088/1361-6420/acf785 </a> </li>
       <li> B. Cockburn, S. Du, and M. A. S&aacute;nchez. A priori error analysis of new semidiscrete, Hamiltonian HDG methods for the time-dependent Maxwell's equations. <br>
-        ESAIM: M2AN, 57 (2023), no.4, 2097 – 2129.
+        ESAIM: M2AN 57 (2023), no. 4, 2097 – 2129.
         <a href="https://doi.org/10.1051/m2an/2023048" target="_blank"> DOI: 10.1051/m2an/2023048 </a> </li>
       <li> S. Du, and S. N. Stechmann. Fast, low-memory numerical methods for radiative transfer via hp-adaptive mesh refinement. <br>
         J. Comput. Phys. 480 (2023).
         <a href="https://doi.org/10.1016/j.jcp.2023.112021" target="_blank"> DOI: 10.1016/j.jcp.2023.112021 </a> </li>
-      <li> S. Du, and S. N. Stechmann. A universal predictor-corrector approach for minimizing artifacts due to mesh refinment. <br>
+      <li> S. Du, and S. N. Stechmann. A universal predictor-corrector approach for minimizing artifacts due to mesh refinement. <br>
         J. Adv. Model. Earth Syst. 15 (2023).
-      <a href="https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2023MS003688" target="_blank"> DOI: 10.1029/2023MS003688 </a> </li>
-      <li> B. Cockburn, S. Du, and M. A. S&aacute;nchez. Combining finite element space-discretization with symplectic time-marching schemes for linear hamiltonian systems. <br>
+        <a href="https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2023MS003688" target="_blank"> DOI: 10.1029/2023MS003688 </a> </li>
+      <li> B. Cockburn, S. Du, and M. A. S&aacute;nchez. Combining finite element space-discretization with symplectic time-marching schemes for linear Hamiltonian systems. <br>
         Front. Appl. Math. Stat. 9 (2023).
         <a href="https://doi.org/10.3389/fams.2023.1165371" target="_blank"> DOI: 10.3389/fams.2023.1165371 </a> </li>
       <li> M. A. S&aacute;nchez, S. Du, B. Cockburn, N.-C. Nguyen, J. Peraire. Symplectic Hamiltonian finite element methods for electromagnetics. <br>
@@ -57,7 +64,7 @@
         Math. Comp. 90 (2021), 65-79.
         <a href="https://doi.org/10.1090/mcom/3573" target="_blank"> DOI: 10.1090/mcom/3573 </a> </li>
       <li> S. Du. HDG methods for the Stokes equation based on strong symmetric stress formulations. <br>
-        J. Sci. Comput. 85, 8 (2020).
+        J. Sci. Comput. 85 (2020), 8.
         <a href="https://doi.org/10.1007/s10915-020-01309-7" target="_blank"> DOI: 10.1007/s10915-020-01309-7 </a> </li>
       <li> S. Du, and F.-J. Sayas. A unified error analysis of hybridizable discontinuous Galerkin methods for the static Maxwell equations. <br>
         SIAM J. Numer. Anal. 58 (2020), no. 2, 1367–1391.
@@ -69,7 +76,7 @@
         Comput. Meth. Appl. Math. 20 (2020), no. 4, 783-798.
         <a href="https://doi.org/10.1515/cmam-2019-0173" target="_blank"> DOI: 10.1515/cmam-2019-0173 </a> </li>
       <li> T.S. Brown, S. Du, H. Eruslu, and F.-J. Sayas. Analysis of models for viscoelastic wave propagation. <br>
-        Appl. Math. Nonlin. Sci. 3 (2018), 55-96.
+        Appl. Math. Nonlin. Sci. 3 (2018), no. 1, 55-96.
         <a href="https://doi.org/10.21042/AMNS.2018.1.00006" target="_blank"> DOI: 10.21042/AMNS.2018.1.00006 </a> </li>
     </ol>
 

--- a/teach.html
+++ b/teach.html
@@ -36,7 +36,7 @@
 
     <h2>TA at University of Delaware</h2>
     <ul style="list-style-type:none;">
-      <li> [2018 Summer] Review of Advanced Mathematical Problems
+      <li> [Fall 2018] Review of Advanced Mathematical Problems
       </li>
       <li> [2016&2017 Fall] Analytic Geometry and Calculus C (Math243)</li>
       <li> [2017 Spring] Analytic Geometry and Calculus B (Math242)</li>


### PR DESCRIPTION
### Motivation
- Synchronize the website with the latest CV by adding office contact info, aligning research-interest wording, refreshing the publications list with recent submissions and peer-reviewed items, and correcting a teaching term.

### Description
- Updated `index.html` to add the office line `Office: Carnegie 206D` and to reword the research interest entry to `Electromagnetic and elastic/viscoelastic waves`.
- Rewrote the publications section in `publications.html`, changed the page header to `Publications`, added two submitted entries and new peer-reviewed items (including J. Quant. Spectrosc. Radiat. Transf. and J. Adv. Model. Earth Syst. entries) and updated DOI links.
- Fixed the teaching entry in `teach.html` by changing `[2018 Summer]` to `[Fall 2018]`.
- Performed small formatting adjustments to ensure the updated content renders correctly across pages.

### Testing
- Launched a local static server with `python -m http.server` and ran a Playwright script to load `http://localhost:8000/index.html` and capture a screenshot, producing `artifacts/index-update.png`, which completed successfully.
- Inspected modified HTML files with line-oriented tools (`sed`/`nl`) to verify the intended edits, and no automated unit tests were applicable because these are static content updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a81ccb5d4832cbae14dd52b80fca0)